### PR TITLE
Remove JSON compilation for non-angular apps

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -53,6 +53,10 @@ const getLanguages = () => {
     - po/lang.json
  */
 async function write(action) {
+    if (process.env.APP_KEY !== 'Angular') {
+        return;
+    }
+
     const spinner = spin('Compiles translations');
     try {
         const list = await getLanguages();

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -14,16 +14,11 @@ async function getConfig() {
 }
 
 async function run({ file, lang }) {
-    const output = `${I18N_JSON_DIR}/${lang}.json`;
-    if (process.env.APP_KEY === 'Angular') {
-        const cmd = `npx angular-gettext-cli --files ${file} --dest ${output} --compile --format json`;
-        debug(cmd);
-        return execa.shell(cmd, {
-            shell: '/bin/bash'
-        });
+    if (process.env.APP_KEY !== 'Angular') {
+        return;
     }
-
-    const cmd = `npx ttag po2json --format=compact ${file} > ${output}`;
+    const output = `${I18N_JSON_DIR}/${lang}.json`;
+    const cmd = `npx angular-gettext-cli --files ${file} --dest ${output} --compile --format json`;
     debug(cmd);
     return execa.shell(cmd, {
         shell: '/bin/bash'

--- a/lib/crowdin.js
+++ b/lib/crowdin.js
@@ -252,7 +252,8 @@ async function listMembers(spinner, format = 'top') {
 
     debug({ format, output: data[format] });
     spinner.stop();
-    fs.writeFileSync(path.join(I18N_JSON_DIR, 'topMembers.json'), JSON.stringify(data[format]));
+    const dir = process.env.APP_KEY !== 'Angular' ? I18N_OUTPUT_DIR : I18N_JSON_DIR;
+    fs.writeFileSync(path.join(dir, 'topMembers.json'), JSON.stringify(data[format]));
     success('Export top members');
 }
 


### PR DESCRIPTION
Now the `.po` are dynamically imported in each application and compiled to json with webpack. So no need to generate the JSON anymore except for the Angular app.